### PR TITLE
refactor: data update workflow and add crawl.sh helper

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -16,10 +16,10 @@ jobs:
   crawl_ubuntu:
     name: Crawl on ubuntu-latest
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -28,26 +28,27 @@ jobs:
         run: |
           pip install -r requirements.txt
       - name: Run ubuntu spiders
+        id: ubuntu_crawl
+        shell: bash
+        env:
+          DATA_FOLDER: ${{ env.DATA_FOLDER }}
         run: |
-          scrapy crawl nthu_announcements
-          scrapy crawl nthu_buses
-          scrapy crawl nthu_courses
-          scrapy crawl nthu_dining
-        continue-on-error: true
-      - name: Cache ubuntu data
-        uses: actions/cache/save@v3
-        if: always()
+          bash ./crawl.sh --group ubuntu
+      - name: Upload ubuntu dataset
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
         with:
+          name: ubuntu-data
           path: ${{ env.DATA_FOLDER }}
-          key: ubuntu-data-${{ github.run_id }}
+          if-no-files-found: error
 
   crawl_self_hosted:
     name: Crawl on self-hosted
     runs-on: self-hosted
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -56,59 +57,70 @@ jobs:
         run: |
           pip install -r requirements.txt
       - name: Run self-hosted spiders
+        id: self_hosted_crawl
+        shell: bash
+        env:
+          DATA_FOLDER: ${{ env.DATA_FOLDER }}
         run: |
-          scrapy crawl nthu_directory
-          scrapy crawl nthu_maps
-          scrapy crawl nthu_newsletters
-        continue-on-error: true
-      - name: Cache self-hosted data
-        uses: actions/cache/save@v3
-        if: always()
+          bash ./crawl.sh --group self-hosted
+      - name: Upload self-hosted dataset
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
         with:
+          name: self-hosted-data
           path: ${{ env.DATA_FOLDER }}
-          key: self-hosted-data-${{ github.run_id }}
+          if-no-files-found: error
 
   commit_changes:
     needs: [crawl_ubuntu, crawl_self_hosted]
-    if: always()
+    if: ${{ always() }}
     name: Commit JSON updates
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-      - name: Restore ubuntu data cache
-        if: needs.crawl_ubuntu.result == 'success'
-        uses: actions/cache/restore@v3
-        with:
-          path: ${{ env.DATA_FOLDER }}
-          key: ubuntu-data-${{ github.run_id }}
-        continue-on-error: true
-      - name: Restore self-hosted data cache
-        if: needs.crawl_self_hosted.result == 'success'
-        uses: actions/cache/restore@v3
-        with:
-          path: ${{ env.DATA_FOLDER }}
-          key: self-hosted-data-${{ github.run_id }}
-        continue-on-error: true
-      - name: Merge data folders
+      - name: Verify crawl availability
+        id: crawl_guard
+        env:
+          UB_SUCCESS: ${{ needs.crawl_ubuntu.result == 'success' }}
+          SH_SUCCESS: ${{ needs.crawl_self_hosted.result == 'success' }}
         run: |
-          mkdir -p ${{ env.DATA_FOLDER }}
-          if [ -d "ubuntu-data" ]; then
-            cp -r ubuntu-data/* ${{ env.DATA_FOLDER }}/ 2>/dev/null || true
+          if [ "${UB_SUCCESS}" != "true" ] && [ "${SH_SUCCESS}" != "true" ]; then
+            echo "No crawl job succeeded; aborting." >&2
+            exit 1
           fi
-          if [ -d "self-hosted-data" ]; then
-            cp -r self-hosted-data/* ${{ env.DATA_FOLDER }}/ 2>/dev/null || true
-          fi
+      - name: Download ubuntu dataset
+        if: ${{ needs.crawl_ubuntu.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ubuntu-data
+          path: ubuntu-data
+      - name: Download self-hosted dataset
+        if: ${{ needs.crawl_self_hosted.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: self-hosted-data
+          path: self-hosted-data
+      - name: Merge data artifacts
+        shell: bash
+        run: |
+          mkdir -p "${DATA_FOLDER}"
+          for source in ubuntu-data self-hosted-data; do
+            if [ -d "$source/${DATA_FOLDER}" ]; then
+              rsync -a "$source/${DATA_FOLDER}/" "${DATA_FOLDER}/"
+            fi
+          done
       - name: Configure Git
         run: |
           git config user.name "GitHub Actions"
           git config user.email "action@github.com"
       - name: Commit data updates
+        shell: bash
         run: |
-          git add $DATA_FOLDER
+          git add "$DATA_FOLDER"
           changed=$(git diff --cached --name-only "$DATA_FOLDER")
           if [[ -n "$changed" ]]; then
             cats=$(echo "$changed" \
@@ -129,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch (full history)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0

--- a/crawl.sh
+++ b/crawl.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Helper script to run Scrapy spiders locally or inside CI.
+
+set -u
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+PYTHON_BIN="python"
+
+declare -a REQUESTED_SPIDERS=()
+
+UBUNTU_GROUP=(
+  "nthu_announcements"
+  "nthu_buses"
+  "nthu_courses"
+  "nthu_dining"
+)
+
+SELF_HOSTED_GROUP=(
+  "nthu_directory"
+  "nthu_maps"
+  "nthu_newsletters"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: crawl.sh [options] [SPIDER...]
+
+Options:
+  --group <name>     Run a predefined group: ubuntu | self-hosted | all
+  --python <bin>     Python interpreter to use when invoking Scrapy (default: python)
+  -h, --help         Show this help message and exit
+
+If no spiders or groups are provided, the script runs all spiders.
+Multiple groups and explicit spider names can be combined.
+EOF
+}
+
+append_group() {
+  case "$1" in
+    ubuntu)
+      REQUESTED_SPIDERS+=("${UBUNTU_GROUP[@]}")
+      ;;
+    self-hosted|self_hosted|selfhosted)
+      REQUESTED_SPIDERS+=("${SELF_HOSTED_GROUP[@]}")
+      ;;
+    all)
+      REQUESTED_SPIDERS+=("${UBUNTU_GROUP[@]}" "${SELF_HOSTED_GROUP[@]}")
+      ;;
+    *)
+      echo "Unknown group: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+while (($#)); do
+  case "$1" in
+    --group)
+      shift || { echo "Missing value for --group" >&2; exit 1; }
+      append_group "$1"
+      ;;
+    --python)
+      shift || { echo "Missing value for --python" >&2; exit 1; }
+      PYTHON_BIN="$1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      REQUESTED_SPIDERS+=("$1")
+      ;;
+  esac
+  shift
+done
+
+if [ ${#REQUESTED_SPIDERS[@]} -eq 0 ]; then
+  REQUESTED_SPIDERS+=("${UBUNTU_GROUP[@]}" "${SELF_HOSTED_GROUP[@]}")
+fi
+
+# Deduplicate while keeping order.
+declare -A SEEN=()
+declare -a SPIDERS=()
+for spider in "${REQUESTED_SPIDERS[@]}"; do
+  if [[ -z ${SEEN[$spider]+x} ]]; then
+    SPIDERS+=("$spider")
+    SEEN[$spider]=1
+  fi
+done
+
+SUCCESS_COUNT=0
+FAIL_COUNT=0
+declare -a FAILED_SPIDERS=()
+
+echo "Running ${#SPIDERS[@]} spider(s)"
+
+for spider in "${SPIDERS[@]}"; do
+  printf '\n=== Crawling %s ===\n' "$spider"
+  if "$PYTHON_BIN" -m scrapy crawl "$spider"; then
+    ((SUCCESS_COUNT++))
+  else
+    ((FAIL_COUNT++))
+    FAILED_SPIDERS+=("$spider")
+  fi
+done
+
+if [ $FAIL_COUNT -gt 0 ]; then
+  printf '\nCompleted with %d failure(s): %s\n' "$FAIL_COUNT" "${FAILED_SPIDERS[*]}" >&2
+  exit 1
+fi
+
+printf '\nAll spiders completed successfully (%d run).\n' "$SUCCESS_COUNT"

--- a/workflow.md
+++ b/workflow.md
@@ -1,0 +1,28 @@
+# Data Update Workflow
+
+This document summarizes the GitHub Actions pipeline that refreshes the scraped datasets and publishes them to GitHub Pages.
+
+## Job Sequence
+- **crawl_ubuntu** – Runs `crawl.sh --group ubuntu` on `ubuntu-latest`, installs dependencies, and uploads the generated `data/` folder as the `ubuntu-data` artifact.
+- **crawl_self_hosted** – Mirrors the ubuntu job on the self-hosted runner with `crawl.sh --group self-hosted`, producing the `self-hosted-data` artifact.
+- **commit_changes** – Always starts once both crawl jobs finish. It downloads whichever artifacts succeeded, merges them into `data/`, commits the changes once, and pushes to `main`.
+- **deploy_to_github** – Regenerates the metadata files and deploys the refreshed `data/` directory to the `gh-pages` branch.
+
+## Failure Isolation
+- Either crawl job may fail (for example, when the self-hosted runner is offline). The `commit_changes` job still runs because it uses `if: ${{ always() }}`.
+- Only successful crawls contribute artifacts, so the merge step gracefully continues with whichever datasets are available.
+- If both crawls fail, the workflow stops during `commit_changes` to avoid pushing stale data.
+
+## Flow Diagram
+```mermaid
+flowchart TD
+  trigger([Push / Schedule / Manual Dispatch]) --> ubuntu[Crawl on ubuntu-latest]
+  trigger --> selfHosted[Crawl on self-hosted runner]
+  ubuntu --> ubArtifact[Upload ubuntu-data artifact]
+  selfHosted --> shArtifact[Upload self-hosted-data artifact]
+  ubArtifact --> commit[Merge & commit JSON data]
+  shArtifact --> commit
+  ubuntu -. failure allowed .-> commit
+  selfHosted -. failure allowed .-> commit
+  commit --> deploy[Deploy to gh-pages]
+```


### PR DESCRIPTION
Replaces manual Scrapy spider invocations in GitHub Actions with a unified crawl.sh script, updates workflow to use upload-artifact/download-artifact instead of cache, and improves error handling and merging of datasets. Adds workflow.md documentation describing the pipeline and its failure isolation. Increases job timeouts and updates actions to latest versions.